### PR TITLE
Improve error handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
+COPY utils/ utils/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/internal/controller/errors.go
+++ b/internal/controller/errors.go
@@ -12,6 +12,10 @@ type ManifestWorkNotReady struct {
 	message string
 }
 
+type ResourceNotFound struct {
+	message string
+}
+
 func (e MisconfiguredManifestError) Error() string {
 	return e.message
 }
@@ -21,5 +25,9 @@ func (e ManifestWorkFailedError) Error() string {
 }
 
 func (e ManifestWorkNotReady) Error() string {
+	return e.message
+}
+
+func (e ResourceNotFound) Error() string {
 	return e.message
 }

--- a/internal/controller/p2codeschedulingmanifest_controller.go
+++ b/internal/controller/p2codeschedulingmanifest_controller.go
@@ -587,40 +587,39 @@ func analysePodSpec(workload *Resource, ancillaryResources ResourceSet) (Resourc
 
 	// Later could support other types and check for aws and azure types
 	// Could also include storage classes
-	if len(podSpec.Volumes) > 0 {
-		for _, volume := range podSpec.Volumes {
-			if volume.PersistentVolumeClaim != nil {
-				pvcResource, err := ancillaryResources.Find(volume.PersistentVolumeClaim.ClaimName, "PersistentVolumeClaim")
-				if err != nil {
-					return ResourceSet{}, err
-				}
 
-				resources.Add(pvcResource)
+	for _, volume := range podSpec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			pvcResource, err := ancillaryResources.Find(volume.PersistentVolumeClaim.ClaimName, "PersistentVolumeClaim")
+			if err != nil {
+				return ResourceSet{}, err
 			}
 
-			// Later check for storage class
-			// pvc := &corev1.PersistentVolumeClaim{}
-			// if err := json.Unmarshal(pvcResource.manifest.Raw, pvc); err != nil {
-			// 	return err
-			// }
+			resources.Add(pvcResource)
+		}
 
-			if volume.ConfigMap != nil {
-				cmResource, err := ancillaryResources.Find(volume.ConfigMap.Name, "ConfigMap")
-				if err != nil {
-					return ResourceSet{}, err
-				}
+		// Later check for storage class
+		// pvc := &corev1.PersistentVolumeClaim{}
+		// if err := json.Unmarshal(pvcResource.manifest.Raw, pvc); err != nil {
+		// 	return err
+		// }
 
-				resources.Add(cmResource)
+		if volume.ConfigMap != nil {
+			cmResource, err := ancillaryResources.Find(volume.ConfigMap.Name, "ConfigMap")
+			if err != nil {
+				return ResourceSet{}, err
 			}
 
-			if volume.Secret != nil {
-				secretResource, err := ancillaryResources.Find(volume.Secret.SecretName, "Secret")
-				if err != nil {
-					return ResourceSet{}, err
-				}
+			resources.Add(cmResource)
+		}
 
-				resources.Add(secretResource)
+		if volume.Secret != nil {
+			secretResource, err := ancillaryResources.Find(volume.Secret.SecretName, "Secret")
+			if err != nil {
+				return ResourceSet{}, err
 			}
+
+			resources.Add(secretResource)
 		}
 	}
 
@@ -639,49 +638,43 @@ func analysePodSpec(workload *Resource, ancillaryResources ResourceSet) (Resourc
 
 	// TODO examine resource requests for container
 	for _, container := range containers {
-		if len(container.EnvFrom) > 0 {
-			for _, envSource := range container.EnvFrom {
-				if envSource.ConfigMapRef != nil {
-					cmResource, err := ancillaryResources.Find(envSource.ConfigMapRef.Name, "ConfigMap")
-					if err != nil {
-						return ResourceSet{}, err
-					}
-
-					resources.Add(cmResource)
+		for _, envSource := range container.EnvFrom {
+			if envSource.ConfigMapRef != nil {
+				cmResource, err := ancillaryResources.Find(envSource.ConfigMapRef.Name, "ConfigMap")
+				if err != nil {
+					return ResourceSet{}, err
 				}
 
-				if envSource.SecretRef != nil {
-					secretResource, err := ancillaryResources.Find(envSource.SecretRef.Name, "Secret")
-					if err != nil {
-						return ResourceSet{}, err
-					}
+				resources.Add(cmResource)
+			}
 
-					resources.Add(secretResource)
+			if envSource.SecretRef != nil {
+				secretResource, err := ancillaryResources.Find(envSource.SecretRef.Name, "Secret")
+				if err != nil {
+					return ResourceSet{}, err
 				}
+
+				resources.Add(secretResource)
 			}
 		}
 
-		if len(container.Env) > 0 {
-			for _, envVar := range container.Env {
-				if envVar.ValueFrom != nil {
-					if envVar.ValueFrom.ConfigMapKeyRef != nil {
-						cmResource, err := ancillaryResources.Find(envVar.ValueFrom.ConfigMapKeyRef.Name, "ConfigMap")
-						if err != nil {
-							return ResourceSet{}, err
-						}
-
-						resources.Add(cmResource)
-					}
-
-					if envVar.ValueFrom.SecretKeyRef != nil {
-						secretResource, err := ancillaryResources.Find(envVar.ValueFrom.SecretKeyRef.Name, "Secret")
-						if err != nil {
-							return ResourceSet{}, err
-						}
-
-						resources.Add(secretResource)
-					}
+		for _, envVar := range container.Env {
+			if envVar.ValueFrom.ConfigMapKeyRef != nil {
+				cmResource, err := ancillaryResources.Find(envVar.ValueFrom.ConfigMapKeyRef.Name, "ConfigMap")
+				if err != nil {
+					return ResourceSet{}, err
 				}
+
+				resources.Add(cmResource)
+			}
+
+			if envVar.ValueFrom.SecretKeyRef != nil {
+				secretResource, err := ancillaryResources.Find(envVar.ValueFrom.SecretKeyRef.Name, "Secret")
+				if err != nil {
+					return ResourceSet{}, err
+				}
+
+				resources.Add(secretResource)
 			}
 		}
 	}

--- a/internal/controller/p2codeschedulingmanifest_controller.go
+++ b/internal/controller/p2codeschedulingmanifest_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/PoolPooer/p2code-scheduler/utils"
 	"github.com/iancoleman/strcase"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -59,6 +60,7 @@ const (
 	schedulingInProgress = "SchedulingInProgress"
 	schedulingSuccessful = "SchedulingSuccessful"
 	schedulingFailed     = "SchedulingFailed"
+	tentativelyScheduled = "TentativelyScheduled"
 	finalizing           = "Finalizing"
 	misconfigured        = "Misconfigured"
 )
@@ -326,9 +328,10 @@ func (r *P2CodeSchedulingManifestReconciler) Reconcile(ctx context.Context, req 
 	} else {
 		err := r.buildBundle(p2CodeSchedulingManifest)
 		var misconfiguredManifestErr *MisconfiguredManifestError
-		if errors.As(err, &misconfiguredManifestErr) {
+		var resourceNotFoundErr *ResourceNotFound
+		if errors.As(err, &misconfiguredManifestErr) || errors.As(err, &resourceNotFoundErr) {
 			log.Error(err, configurationIssue)
-			condition := metav1.Condition{Type: misconfigured, Status: metav1.ConditionTrue, Reason: "MisconfiguredManifest", Message: err.Error()}
+			condition := metav1.Condition{Type: misconfigured, Status: metav1.ConditionTrue, Reason: "MisconfiguredManifest", Message: utils.Capitalise(err.Error())}
 			if err := r.UpdateStatus(p2CodeSchedulingManifest, condition, []schedulingv1alpha1.SchedulingDecision{}); err != nil {
 				log.Error(err, updateFailure)
 				return ctrl.Result{}, err
@@ -406,7 +409,7 @@ func (r *P2CodeSchedulingManifestReconciler) Reconcile(ctx context.Context, req 
 			if errors.As(err, &misconfiguredManifestErr) {
 				log.Error(err, configurationIssue)
 
-				condition := metav1.Condition{Type: misconfigured, Status: metav1.ConditionTrue, Reason: "MisconfiguredManifest", Message: err.Error()}
+				condition := metav1.Condition{Type: misconfigured, Status: metav1.ConditionTrue, Reason: "MisconfiguredManifest", Message: utils.Capitalise(err.Error())}
 				if err := r.UpdateStatus(p2CodeSchedulingManifest, condition, []schedulingv1alpha1.SchedulingDecision{}); err != nil {
 					log.Error(err, updateFailure)
 					return ctrl.Result{}, err
@@ -422,27 +425,6 @@ func (r *P2CodeSchedulingManifestReconciler) Reconcile(ctx context.Context, req 
 
 			manifestWorks = append(manifestWorks, newManifestWork)
 		}
-	}
-
-	// Ensure there are no orphaned manifests
-	// Orphaned manifests can arise if there are ancillary services that are not referenced by a workload resource and are therefore not added to a bundle
-	// If there are more manifests in the CR than the count of manifests across all ManifestWorks this indicates that some manifests are unaccounted for
-	// It is unlikely that the values are equal since an ancillary manifest can be included in many ManifestWorks
-	if len(p2CodeSchedulingManifest.Spec.Manifests) > placedManifests {
-		errorTitle := "orphaned manifest"
-		errorMessage := "Orphaned manifests found: Ensure all ancillary resources (services, configmaps, secrets, etc) are referenced by a workload resource"
-
-		err := fmt.Errorf("%s", errorTitle)
-		log.Error(err, errorMessage)
-
-		condition := metav1.Condition{Type: misconfigured, Status: metav1.ConditionTrue, Reason: strcase.ToCamel(errorTitle), Message: errorMessage}
-		if err := r.UpdateStatus(p2CodeSchedulingManifest, condition, []schedulingv1alpha1.SchedulingDecision{}); err != nil {
-			log.Error(err, updateFailure)
-			return ctrl.Result{}, err
-		}
-
-		// End reconciliation as it is not permitted to have orphaned manifests
-		return ctrl.Result{}, nil
 	}
 
 	log.Info("Ready to push ManifestWork(s) to schedule the workload to the identified cluster")
@@ -477,7 +459,7 @@ func (r *P2CodeSchedulingManifestReconciler) Reconcile(ctx context.Context, req 
 		if errors.As(err, &manifestWorkFailedErr) {
 			log.Error(err, "Failed to apply ManifestWork")
 
-			condition := metav1.Condition{Type: schedulingFailed, Status: metav1.ConditionTrue, Reason: "ManifestWorkFailed", Message: err.Error()}
+			condition := metav1.Condition{Type: schedulingFailed, Status: metav1.ConditionTrue, Reason: "ManifestWorkFailed", Message: utils.Capitalise(err.Error())}
 			schedulingDecisions := r.getSchedulingDecisions(p2CodeSchedulingManifest)
 			if err := r.UpdateStatus(p2CodeSchedulingManifest, condition, schedulingDecisions); err != nil {
 				log.Error(err, updateFailure)
@@ -494,6 +476,24 @@ func (r *P2CodeSchedulingManifestReconciler) Reconcile(ctx context.Context, req 
 			log.Error(err, "Error occurred while validating the state of the ManifestWork applied")
 			return ctrl.Result{}, err
 		}
+	}
+
+	// Check for orphaned manifests
+	// Orphaned manifests can arise if there are ancillary services that are not referenced by a workload resource and are therefore not added to a bundle
+	// If there are more manifests in the CR than the count of manifests across all ManifestWorks this indicates that some manifests are unaccounted for
+	// It is unlikely that the values are equal since an ancillary manifest can be included in many ManifestWorks
+	if len(p2CodeSchedulingManifest.Spec.Manifests) > placedManifests {
+		warningMessage := "All workloads have been successfully scheduled however orphaned manifests have been found, ensure all ancillary resources (services, configmaps, secrets, etc) are referenced by a workload resource"
+		log.Info(warningMessage)
+
+		condition := metav1.Condition{Type: tentativelyScheduled, Status: metav1.ConditionTrue, Reason: "OrphanedManifest", Message: warningMessage}
+		if err := r.UpdateStatus(p2CodeSchedulingManifest, condition, []schedulingv1alpha1.SchedulingDecision{}); err != nil {
+			log.Error(err, updateFailure)
+			return ctrl.Result{}, err
+		}
+
+		// End reconciliation
+		return ctrl.Result{}, nil
 	}
 
 	message := "All workloads have been successfully scheduled to a suitable cluster"
@@ -528,115 +528,12 @@ func analyseWorkload(workload *Resource, ancillaryResources ResourceSet) (Resour
 		resources.Add(namespaceResource)
 	}
 
-	podSpec, err := extractPodSpec(*workload)
+	rs, err := analysePodSpec(workload, ancillaryResources)
 	if err != nil {
 		return ResourceSet{}, []string{}, err
+	} else {
+		resources = append(resources, rs...)
 	}
-
-	// Open question is there a need to consider nodeSelector, tolerations
-
-	// Later could support other types and check for aws and azure types
-	// Could also include storage classes
-	if len(podSpec.Volumes) > 0 {
-		for _, volume := range podSpec.Volumes {
-			if volume.PersistentVolumeClaim != nil {
-				pvcResource, err := ancillaryResources.Find(volume.PersistentVolumeClaim.ClaimName, "PersistentVolumeClaim")
-				if err != nil {
-					return ResourceSet{}, []string{}, err
-				}
-
-				resources.Add(pvcResource)
-			}
-
-			// Later check for storage class
-			// pvc := &corev1.PersistentVolumeClaim{}
-			// if err := json.Unmarshal(pvcResource.manifest.Raw, pvc); err != nil {
-			// 	return err
-			// }
-
-			if volume.ConfigMap != nil {
-				cmResource, err := ancillaryResources.Find(volume.ConfigMap.Name, "ConfigMap")
-				if err != nil {
-					return ResourceSet{}, []string{}, err
-				}
-
-				resources.Add(cmResource)
-			}
-
-			if volume.Secret != nil {
-				secretResource, err := ancillaryResources.Find(volume.Secret.SecretName, "Secret")
-				if err != nil {
-					return ResourceSet{}, []string{}, err
-				}
-
-				resources.Add(secretResource)
-			}
-		}
-	}
-
-	if podSpec.ServiceAccountName != "" {
-		saResource, err := ancillaryResources.Find(podSpec.ServiceAccountName, "ServiceAccount")
-		if err != nil {
-			return ResourceSet{}, []string{}, err
-		}
-
-		resources.Add(saResource)
-	}
-
-	// Examine Containers and InitContainers for ancillary resources
-	containers := podSpec.Containers
-	containers = append(containers, podSpec.InitContainers...)
-
-	// TODO examine resource requests for container
-	for _, container := range containers {
-		if len(container.EnvFrom) > 0 {
-			for _, envSource := range container.EnvFrom {
-				if envSource.ConfigMapRef != nil {
-					cmResource, err := ancillaryResources.Find(envSource.ConfigMapRef.Name, "ConfigMap")
-					if err != nil {
-						return ResourceSet{}, []string{}, err
-					}
-
-					resources.Add(cmResource)
-				}
-
-				if envSource.SecretRef != nil {
-					secretResource, err := ancillaryResources.Find(envSource.SecretRef.Name, "Secret")
-					if err != nil {
-						return ResourceSet{}, []string{}, err
-					}
-
-					resources.Add(secretResource)
-				}
-			}
-		}
-
-		if len(container.Env) > 0 {
-			for _, envVar := range container.Env {
-				if envVar.ValueFrom != nil {
-					if envVar.ValueFrom.ConfigMapKeyRef != nil {
-						cmResource, err := ancillaryResources.Find(envVar.ValueFrom.ConfigMapKeyRef.Name, "ConfigMap")
-						if err != nil {
-							return ResourceSet{}, []string{}, err
-						}
-
-						resources.Add(cmResource)
-					}
-
-					if envVar.ValueFrom.SecretKeyRef != nil {
-						secretResource, err := ancillaryResources.Find(envVar.ValueFrom.SecretKeyRef.Name, "Secret")
-						if err != nil {
-							return ResourceSet{}, []string{}, err
-						}
-
-						resources.Add(secretResource)
-					}
-				}
-			}
-		}
-	}
-
-	// Look into securityContextProfile under container and pod for later version
 
 	// TODO test this case
 	// Add services to the bundle
@@ -674,6 +571,122 @@ func analyseWorkload(workload *Resource, ancillaryResources ResourceSet) (Resour
 	}
 
 	return resources, externalConnections, nil
+}
+
+func analysePodSpec(workload *Resource, ancillaryResources ResourceSet) (ResourceSet, error) {
+	resources := ResourceSet{}
+
+	podSpec, err := extractPodSpec(*workload)
+	if err != nil {
+		return ResourceSet{}, err
+	}
+
+	// Open question is there a need to consider nodeSelector, tolerations
+
+	// TODO analyse securityContextProfile under container and pod for later version
+
+	// Later could support other types and check for aws and azure types
+	// Could also include storage classes
+	if len(podSpec.Volumes) > 0 {
+		for _, volume := range podSpec.Volumes {
+			if volume.PersistentVolumeClaim != nil {
+				pvcResource, err := ancillaryResources.Find(volume.PersistentVolumeClaim.ClaimName, "PersistentVolumeClaim")
+				if err != nil {
+					return ResourceSet{}, err
+				}
+
+				resources.Add(pvcResource)
+			}
+
+			// Later check for storage class
+			// pvc := &corev1.PersistentVolumeClaim{}
+			// if err := json.Unmarshal(pvcResource.manifest.Raw, pvc); err != nil {
+			// 	return err
+			// }
+
+			if volume.ConfigMap != nil {
+				cmResource, err := ancillaryResources.Find(volume.ConfigMap.Name, "ConfigMap")
+				if err != nil {
+					return ResourceSet{}, err
+				}
+
+				resources.Add(cmResource)
+			}
+
+			if volume.Secret != nil {
+				secretResource, err := ancillaryResources.Find(volume.Secret.SecretName, "Secret")
+				if err != nil {
+					return ResourceSet{}, err
+				}
+
+				resources.Add(secretResource)
+			}
+		}
+	}
+
+	if podSpec.ServiceAccountName != "" {
+		saResource, err := ancillaryResources.Find(podSpec.ServiceAccountName, "ServiceAccount")
+		if err != nil {
+			return ResourceSet{}, err
+		}
+
+		resources.Add(saResource)
+	}
+
+	// Examine Containers and InitContainers for ancillary resources
+	containers := podSpec.Containers
+	containers = append(containers, podSpec.InitContainers...)
+
+	// TODO examine resource requests for container
+	for _, container := range containers {
+		if len(container.EnvFrom) > 0 {
+			for _, envSource := range container.EnvFrom {
+				if envSource.ConfigMapRef != nil {
+					cmResource, err := ancillaryResources.Find(envSource.ConfigMapRef.Name, "ConfigMap")
+					if err != nil {
+						return ResourceSet{}, err
+					}
+
+					resources.Add(cmResource)
+				}
+
+				if envSource.SecretRef != nil {
+					secretResource, err := ancillaryResources.Find(envSource.SecretRef.Name, "Secret")
+					if err != nil {
+						return ResourceSet{}, err
+					}
+
+					resources.Add(secretResource)
+				}
+			}
+		}
+
+		if len(container.Env) > 0 {
+			for _, envVar := range container.Env {
+				if envVar.ValueFrom != nil {
+					if envVar.ValueFrom.ConfigMapKeyRef != nil {
+						cmResource, err := ancillaryResources.Find(envVar.ValueFrom.ConfigMapKeyRef.Name, "ConfigMap")
+						if err != nil {
+							return ResourceSet{}, err
+						}
+
+						resources.Add(cmResource)
+					}
+
+					if envVar.ValueFrom.SecretKeyRef != nil {
+						secretResource, err := ancillaryResources.Find(envVar.ValueFrom.SecretKeyRef.Name, "Secret")
+						if err != nil {
+							return ResourceSet{}, err
+						}
+
+						resources.Add(secretResource)
+					}
+				}
+			}
+		}
+	}
+
+	return resources, nil
 }
 
 func (r *P2CodeSchedulingManifestReconciler) getAssociatedPlacement(bundle *Bundle, p2CodeSchedulingManifest *schedulingv1alpha1.P2CodeSchedulingManifest) (*clusterv1beta1.Placement, error) {

--- a/internal/controller/resourceset.go
+++ b/internal/controller/resourceset.go
@@ -66,7 +66,8 @@ func (resourceSet *ResourceSet) Find(name string, kind string) (*Resource, error
 		}
 	}
 
-	return nil, fmt.Errorf("cannot find a resource of type %s with the name %s", kind, name)
+	errorMessage := fmt.Sprintf("cannot find a resource of type %s with the name %s", kind, name)
+	return nil, &ResourceNotFound{errorMessage}
 }
 
 func (resourceSet *ResourceSet) FindWorkload(name string) (*Resource, error) {
@@ -76,7 +77,8 @@ func (resourceSet *ResourceSet) FindWorkload(name string) (*Resource, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("cannot find a workload resource with the name %s", name)
+	errorMessage := fmt.Sprintf("cannot find a workload resource with the name %s", name)
+	return nil, &ResourceNotFound{errorMessage}
 }
 
 func (resourceSet *ResourceSet) FilterByKind(kind string) ResourceSet {


### PR DESCRIPTION
Tentatively schedule if orphaned manifests are found. Throw ManifestMisconfigured error if a workload references an ancillary resource that cannot be found.